### PR TITLE
Fix for linux >=5.1 "get_ds" removed

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1290,7 +1290,7 @@ static int isFileReadable(const char *path, u32 *sz)
 		ret = PTR_ERR(fp);
 	else {
 		oldfs = get_fs();
-		set_fs(get_ds());
+		set_fs(KERNEL_DS);
 
 		if (1 != readFile(fp, &buf, 1))
 			ret = PTR_ERR(fp);
@@ -1328,7 +1328,7 @@ static int retriveFromFile(const char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			set_fs(KERNEL_DS);
 			ret = readFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);
@@ -1363,7 +1363,7 @@ static int storeToFile(const char *path, u8 *buf, u32 sz)
 			RTW_INFO("%s openFile path:%s fp=%p\n", __FUNCTION__, path , fp);
 
 			oldfs = get_fs();
-			set_fs(get_ds());
+			set_fs(KERNEL_DS);
 			ret = writeFile(fp, buf, sz);
 			set_fs(oldfs);
 			closeFile(fp);
@@ -1786,7 +1786,7 @@ int map_readN(const struct map_t *map, u16 offset, u16 len, u8 *buf)
 			else
 				c_len = seg->sa + seg->len - offset;
 		}
-			
+
 		_rtw_memcpy(c_dst, c_src, c_len);
 	}
 


### PR DESCRIPTION
Since commit 736706bee3298208343a76096370e4f6a5c55915 get_ds was removed which is internally mapped to KERNEL_DS.

Signed-off-by: John-Eric Kamps <john-eric.kamps@honeywell.com>