### PR TITLE
 rtl8723ds: Fix build with kernel 5.15

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -20,10 +20,13 @@
 #define _RTW_BR_EXT_C_
 
 #ifdef __KERNEL__
+	#include <linux/version.h>
 	#include <linux/if_arp.h>
 	#include <net/ip.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	#include <net/ipx.h>
 	#include <linux/atalk.h>
+#endif
 	#include <linux/udp.h>
 	#include <linux/if_pppox.h>
 #endif
@@ -892,7 +895,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 			return -1;
 		}
 	}
-
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	/*---------------------------------------------------*/
 	/*         Handle IPX and Apple Talk frame          */
 	/*---------------------------------------------------*/
@@ -1113,7 +1116,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 
 		return -1;
 	}
-
+#endif
 	/*---------------------------------------------------*/
 	/*                Handle PPPoE frame                */
 	/*---------------------------------------------------*/


### PR DESCRIPTION
@lwfinger Please add the following fix, which is based on your one for the rtl8192ee.
https://github.com/lwfinger/rtl8192ee/commit/74278ad1b2d8ec703435fc22651b82df8f4e8700?diff=unified

Tested with linux 5.16

Signed-off-by: John-Eric Kamps <johnny86@gmx.de>