### PR TITLE
Makefile: Generic configuration for riscv platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,9 @@ CONFIG_PLATFORM_RTK119X = n
 CONFIG_PLATFORM_RTK129X = n
 CONFIG_PLATFORM_NOVATEK_NT72668 = n
 CONFIG_PLATFORM_HISILICON = n
+# Config for riscv is at a fundamental level. 
+# Further modification may be required.
+CONFIG_PLATFORM_RISCV = n
 ###############################################################
 
 CONFIG_DRVEXT_MODULE = n
@@ -1719,6 +1722,12 @@ CROSS_COMPILE := /home/android_sdk/Telechips/v13.05_r1-tcc-android-4.2.2_tcc893x
 KSRC := /home/android_sdk/Telechips/v13.05_r1-tcc-android-4.2.2_tcc893x-evm_build/kernel
 MODULE_NAME := wlan
 endif 
+
+ifeq ($(CONFIG_PLATFORM_RISCV), y)
+# This is a gereric config. More modification may be required.
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+ARCH := riscv
+endif
 
 ifeq ($(CONFIG_MULTIDRV), y)
 


### PR DESCRIPTION
Sipeed's Allwinner D1-based board Lichee RV Dock uses rtl8723ds as its wireless module, which lacks of building support for riscv64 architecture. This pull request will add basic Makefile configuration for riscv64 building target. 

Experimental package for AOSC OS is available at https://github.com/AOSC-Dev/aosc-os-bsps/tree/riscv-sunxi-sun20i/noarch-dkms/rtl8723ds (Not uploaded yet) , and tests functional on my board.
![image](https://user-images.githubusercontent.com/22998116/171350138-794dda5c-8b4b-43d6-af1e-d35acc5cfa82.png)
