### PR TITLE
rtl8723ds: remove raw_spinlock on RT

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -144,11 +144,7 @@
 
 
 typedef struct	semaphore _sema;
-#ifdef CONFIG_PREEMPT_RT
-typedef	raw_spinlock_t	_lock;
-#else
 typedef	spinlock_t	_lock;
-#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 37))
 	typedef struct mutex		_mutex;
 #else
@@ -232,23 +228,6 @@ __inline static _list	*get_list_head(_queue	*queue)
 	((type *)((char *)(ptr)-(SIZE_T)(&((type *)0)->member)))
 
 
-#ifdef CONFIG_PREEMPT_RT
-__inline static void _enter_critical(_lock *plock, unsigned long *pirqL)
-{
-	raw_spin_lock_irqsave(plock, *pirqL);
-}
-
-__inline static void _exit_critical(_lock *plock, unsigned long *pirqL)
-{
-	raw_spin_unlock_irqrestore(plock, *pirqL);
-}
-
-__inline static void _enter_critical_ex(_lock *plock, unsigned long *pirqL)
-{
-	raw_spin_lock_irqsave(plock, *pirqL);
-}
-
-#else
 __inline static void _enter_critical(_lock *plock, _irqL *pirqL)
 {
 	spin_lock_irqsave(plock, *pirqL);
@@ -263,7 +242,6 @@ __inline static void _enter_critical_ex(_lock *plock, _irqL *pirqL)
 {
 	spin_lock_irqsave(plock, *pirqL);
 }
-#endif
 
 __inline static void _exit_critical_ex(_lock *plock, _irqL *pirqL)
 {


### PR DESCRIPTION
There's no need for a raw spinlock in this driver as it doesn't do
anything in hardirq context on -rt.  Some of the critical sections
guarded by these locks are long and contain unbounded loops so there is
a risk of raw spinlocks causing latency spikes on -rt.

The existing code is broken with CONFIG_PREEMPT_RT anyway as only a
subset of the functions that depend on lock type are covered by the
preprocessor #if/#else blocks.

Remove the special-case for CONFIG_PREEMPT_RT.

Signed-off-by: John Keeping <john@metanate.com>