### PR TITLE
rtl8723ds: fix tag_len read in __nat25_add_pppoe_tag()

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -112,7 +112,7 @@ static __inline__ int __nat25_add_pppoe_tag(struct sk_buff *skb, struct pppoe_ta
 	struct pppoe_hdr *ph = (struct pppoe_hdr *)(skb->data + ETH_HLEN);
 	int data_len;
 
-	data_len = tag->tag_len + TAG_HDR_LEN;
+	data_len = ntohs(tag->tag_len) + TAG_HDR_LEN;
 	if (skb_tailroom(skb) < data_len) {
 		_DEBUG_ERR("skb_tailroom() failed in add SID tag!\n");
 		return -1;


### PR DESCRIPTION
pppoe_tag::tag_len is declared as __be16 so it needs to be converted
when reading.  All other sites in this file that use this field already
do the right thing here.

Signed-off-by: John Keeping <john@metanate.com>