### PR TITLE
rtl8723ds: fix rtw_mfree_stainfo()

### DIFF
--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -335,9 +335,7 @@ void rtw_mfree_stainfo(struct sta_info *psta);
 void rtw_mfree_stainfo(struct sta_info *psta)
 {
 
-	if (&psta->lock != NULL)
-		_rtw_spinlock_free(&psta->lock);
-
+	_rtw_spinlock_free(&psta->lock);
 	_rtw_free_sta_xmit_priv_lock(&psta->sta_xmitpriv);
 	_rtw_free_sta_recv_priv_lock(&psta->sta_recvpriv);
 


### PR DESCRIPTION
Building with GCC 12.2 results in:

    /var/lib/dkms/licheerv-rtl8723ds/1.0/build/core/rtw_sta_mgt.c: In function ‘rtw_mfree_stainfo’:
    /var/lib/dkms/licheerv-rtl8723ds/1.0/build/core/rtw_sta_mgt.c:338:25: warning: the comparison will always evaluate as ‘true’ 
    for the address of ‘lock’ will never be NULL [-Waddress]
      338 |         if (&psta->lock != NULL)
          |

Remove the superfluous check.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>