### PR TITLE
rtl8723ds: fix sta_info alignment

### DIFF
--- a/core/rtw_sta_mgt.c
+++ b/core/rtw_sta_mgt.c
@@ -222,13 +222,12 @@ u32	_rtw_init_sta_priv(struct	sta_priv *pstapriv)
 	s32 i;
 
 
-	pstapriv->pallocated_stainfo_buf = rtw_zvmalloc(sizeof(struct sta_info) * NUM_STA + 4);
+	pstapriv->pallocated_stainfo_buf = rtw_zvmalloc(sizeof(struct sta_info) * NUM_STA);
 
 	if (!pstapriv->pallocated_stainfo_buf)
 		return _FAIL;
 
-	pstapriv->pstainfo_buf = pstapriv->pallocated_stainfo_buf + 4 -
-			 ((SIZE_PTR)(pstapriv->pallocated_stainfo_buf) & 3);
+	pstapriv->pstainfo_buf = pstapriv->pallocated_stainfo_buf;
 
 	_rtw_init_queue(&pstapriv->free_sta_queue);
 
@@ -423,7 +422,7 @@ u32	_rtw_free_sta_priv(struct	sta_priv *pstapriv)
 #endif
 
 		if (pstapriv->pallocated_stainfo_buf)
-			rtw_vmfree(pstapriv->pallocated_stainfo_buf, sizeof(struct sta_info) * NUM_STA + 4);
+			rtw_vmfree(pstapriv->pallocated_stainfo_buf, sizeof(struct sta_info) * NUM_STA);
 	}
 
 	return _SUCCESS;


### PR DESCRIPTION
Allocation function return memory that is properly aligned for most data types, there is no need to manually align the buffer later.

On 64-bit systems this is particularly wrong as struct sta_info should be 8-byte aligned so this calculation is guaranteed to misalign the structure.  If the architecture requires aligned access, this leads to an alignment fault and panic.

Signed-off-by: John Keeping <john@metanate.com>