### PR TITLE
rtl8723ds: fix rtnl_lock handling

### DIFF
--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1402,13 +1402,7 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 
 	/* Tell the network stack we exist */
 
-	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26))
-	if (!rtnl_is_locked())
-		ret = (register_netdev(ndev) == 0) ? _SUCCESS : _FAIL;
-	else
-	#endif
-		ret = (register_netdevice(ndev) == 0) ? _SUCCESS : _FAIL;
-
+	ret = (register_netdev(ndev) == 0) ? _SUCCESS : _FAIL;
 	if (ret == _SUCCESS)
 		adapter->registered = 1;
 	else
@@ -1447,14 +1441,8 @@ void rtw_os_ndev_unregister(_adapter *adapter)
 	rtw_cfg80211_ndev_res_unregister(adapter);
 #endif
 
-	if ((adapter->DriverState != DRIVER_DISAPPEAR) && netdev) {
-		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26))
-		if (!rtnl_is_locked())
-			unregister_netdev(netdev);
-		else
-		#endif
-			unregister_netdevice(netdev);
-	}
+	if ((adapter->DriverState != DRIVER_DISAPPEAR) && netdev)
+		unregister_netdev(netdev);
 
 #if defined(CONFIG_IOCTL_CFG80211) && !defined(RTW_SINGLE_WIPHY)
 	rtw_wiphy_unregister(adapter_to_wiphy(adapter));

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -1516,10 +1516,6 @@ RETURN:
 	return;
 }
 
-/*
-* Jeff: this function should be called under ioctl (rtnl_lock is accquired) while
-* LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 26)
-*/
 int rtw_change_ifname(_adapter *padapter, const char *ifname)
 {
 	struct net_device *pnetdev;
@@ -1539,12 +1535,7 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 		rereg_priv->old_pnetdev = NULL;
 	}
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26))
-	if (!rtnl_is_locked())
-		unregister_netdev(cur_pnetdev);
-	else
-#endif
-		unregister_netdevice(cur_pnetdev);
+	unregister_netdevice(cur_pnetdev);
 
 	rereg_priv->old_pnetdev = cur_pnetdev;
 
@@ -1564,12 +1555,7 @@ int rtw_change_ifname(_adapter *padapter, const char *ifname)
 	dev_addr_set(pnetdev, adapter_mac_addr(padapter));
 #endif
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 26))
-	if (!rtnl_is_locked())
-		ret = register_netdev(pnetdev);
-	else
-#endif
-		ret = register_netdevice(pnetdev);
+	ret = register_netdevice(pnetdev);
 
 	if (ret != 0) {
 		goto error;


### PR DESCRIPTION
The important commit here fixes the locking in `rtw_os_ndev_register()` and `rtw_os_ndev_unregister()`; the other commit is just removing an unnecessary check since we're guaranteed to already hold `rtnl_lock`.

For registration, I have seen cases where `register_netdevice()` is being called without holding `rtnl_lock` because it is being held by another task and this breaks all the locking requirements.